### PR TITLE
re

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -189,7 +189,7 @@
       <workItem from="1566813994580" duration="380000" />
       <workItem from="1566814512158" duration="1401000" />
       <workItem from="1566824465494" duration="106312000" />
-      <workItem from="1567579401030" duration="31445000" />
+      <workItem from="1567579401030" duration="31870000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="eba9aea2-2187-4298-8d19-a63eb7820ff5" name="Default Changelist" comment="">
-      <change afterPath="$PROJECT_DIR$/notes/.dockerignore" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/notes/Dockerfile" beforeDir="false" afterPath="$PROJECT_DIR$/notes/Dockerfile" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/notes/ormconfig.json" beforeDir="false" afterPath="$PROJECT_DIR$/notes/ormconfig.json" afterDir="false" />
@@ -189,7 +188,7 @@
       <workItem from="1566813994580" duration="380000" />
       <workItem from="1566814512158" duration="1401000" />
       <workItem from="1566824465494" duration="106312000" />
-      <workItem from="1567579401030" duration="31870000" />
+      <workItem from="1567579401030" duration="32150000" />
     </task>
     <servers />
   </component>

--- a/notes/.gitignore
+++ b/notes/.gitignore
@@ -395,7 +395,6 @@ Temporary Items
 
 =======
 # Local
-docker-compose.yml
 .env
 dist
 /sessions

--- a/notes/Dockerfile
+++ b/notes/Dockerfile
@@ -11,7 +11,6 @@
 #EXPOSE 3000
 #
 #ENTRYPOINT ["npm","run","start"]
-
 FROM node:latest
 WORKDIR /app
 COPY package.json .

--- a/notes/docker-compose.yml
+++ b/notes/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+services:
+  postgres:
+    container_name: postgres
+    image: postgres:latest
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+    expose:
+      - 5432
+  redis:
+    container_name: redis
+    image: redis:latest
+    expose:
+      - 6379
+  mongo:
+    container_name: mongo
+    image: mongo:latest
+    expose:
+      - 27017
+  app:
+    container_name: app
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 3000:3000
+    depends_on:
+    - redis
+    - mongo
+    - postgres
+    volumes:
+      - ./:/app

--- a/notes/ormconfig.json
+++ b/notes/ormconfig.json
@@ -1,3 +1,4 @@
+
 {
   "type": "postgres",
   "host": "postgres",

--- a/notes/src/app.module.ts
+++ b/notes/src/app.module.ts
@@ -29,8 +29,7 @@ import { MongooseModule } from '@nestjs/mongoose';
       host: 'redis',
       port: 6379,
       password: '12345',
-    }),
-    MongooseModule.forRoot('mongodb://mongo:27017',
+    }), MongooseModule.forRoot('mongodb://mongo:27017',
       {
         useNewUrlParser: true,
       }),

--- a/notes/src/dbTables/likes/likesTable.module.ts
+++ b/notes/src/dbTables/likes/likesTable.module.ts
@@ -7,8 +7,7 @@ import { Users } from '../users/usersTable.entity';
 import { MongoModule } from 'nest-mongodb';
 @Module({
   imports: [TypeOrmModule.forFeature([Likes, Notes, Users]),
-    MongoModule.forRoot('mongodb://mongo:27017', 'usersdb'),
-  ],
+    MongoModule.forRoot('mongodb://mongo:27017', 'usersdb')],
   providers: [LikesTableService],
   exports: [LikesTableService],
 })

--- a/notes/src/dbTables/tags/tagsTable.module.ts
+++ b/notes/src/dbTables/tags/tagsTable.module.ts
@@ -10,8 +10,7 @@ import { Users } from '../users/usersTable.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Tags, Notes, Users]),
-    MongoModule.forRoot('mongodb://mongo:27017', 'usersdb'),
-    NotesModule, UsersTableModule],
+    MongoModule.forRoot('mongodb://mongo:27017', 'usersdb'), NotesModule, UsersTableModule],
   providers: [TagsTableService],
   exports: [TagsTableService],
 })

--- a/notes/src/dbTables/users/usersTable.module.ts
+++ b/notes/src/dbTables/users/usersTable.module.ts
@@ -6,8 +6,7 @@ import { MongoModule } from 'nest-mongodb';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Users]),
-    MongoModule.forRoot('mongodb://mongo:27017', 'usersdb'),
-  ],
+    MongoModule.forRoot('mongodb://mongo:27017', 'usersdb')],
   providers: [UsersTableService],
   exports: [UsersTableService],
 })


### PR DESCRIPTION
(node:18) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
[Nest] 18 - 09/05/2019, 8:46 AM [TypeOrmModule] Unable to connect to the database. Retrying (1)... +24ms
Error: getaddrinfo ENOTFOUND postgres
at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:60:26)
[ioredis] Unhandled error event: Error: getaddrinfo ENOTFOUND redis
at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:60:26)
[Nest] 18 - 09/05/2019, 8:46 AM [MongooseModule] Unable to connect to the database. Retrying (1)... +30ms
[Nest] 18 - 09/05/2019, 8:46 AM [ExceptionHandler] failed to connect to server [mongo:27017] on first connect [Error: getaddrinfo ENOTFOUND mongo
at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:60:26) {
name: 'MongoNetworkError',
errorLabels: [Array],
[Symbol(mongoErrorContextSymbol)]: {}
}] +14ms
MongoNetworkError: failed to connect to server [mongo:27017] on first connect [Error: getaddrinfo ENOTFOUND mongo
at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:60:26) {
name: 'MongoNetworkError',
errorLabels: [Array],
[Symbol(mongoErrorContextSymbol)]: {}
}]
at Pool. (/app/node_modules/mongodb/lib/core/topologies/server.js:431:11)
at Pool.emit (events.js:209:13)
at Pool.EventEmitter.emit (domain.js:476:20)
at /app/node_modules/mongodb/lib/core/connection/pool.js:580:14
at /app/node_modules/mongodb/lib/core/connection/connect.js:39:11
at callback (/app/node_modules/mongodb/lib/core/connection/connect.js:261:5)
at Socket. (/app/node_modules/mongodb/lib/core/connection/connect.js:286:7)
at Object.onceWrapper (events.js:297:20)
at Socket.emit (events.js:209:13)
at Socket.EventEmitter.emit (domain.js:476:20)
at emitErrorNT (internal/streams/destroy.js:91:8)
at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
at processTicksAndRejections (internal/process/task_queues.js:77:11)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! c@0.0.1 start: ts-node -r tsconfig-paths/register src/index.ts
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the c@0.0.1 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR! /root/.npm/_logs/2019-09-05T08_46_35_115Z-debug.log
ERROR: Service 'app' failed to build: The command '/bin/sh -c npm run start' returned a non-zero code: 1